### PR TITLE
Don't use "Thread" for s3 objects

### DIFF
--- a/lib/cfn-flow/template.rb
+++ b/lib/cfn-flow/template.rb
@@ -58,7 +58,7 @@ class CfnFlow::Template
   end
 
   def s3_object
-    Thread.current[:aws_s3_object] ||= Aws::S3::Object.new(bucket, key)
+    Aws::S3::Object.new(bucket, key)
   end
 
 end


### PR DESCRIPTION
All templates end up getting uploaded to the same s3 file (the first
one uploaded) with each successive upload overwriting the one before
it.
