### PR TITLE
Support stack outputs as parameters in cfn-flow.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,21 @@ stack:
       # Your parameters, e.g.:
       vpcid: vpc-1234
       ami: ami-abcd
+
+      ##
+      # Use outputs from other stacks
+
+      # This set the `load_balancer` parameter to the value of the
+      # `elbname` output of `my-elb-stack`
+      load_balancer:
+        stack: my-elb-stack
+        output: elbname
+
+      # If you don't specify the output name, it's assumed to be same
+      # as the parameter key:
+      ssh_security_group:
+        stack: my-bastion-stack
+
     disable_rollback: true,
     timeout_in_minutes: 1,
     notification_arns: ["NotificationARN"],
@@ -227,6 +242,23 @@ stack:
   ...
   parameters:
     git_sha: <%= `git rev-parse --verify HEAD`.chomp %>
+```
+
+#### Use stack outputs as parameters
+`cfn-flow` lets you easily reference stack outputs as parameters for new stacks.
+
+```yaml
+# cfn-flow.yml
+stack:
+  parameters:
+    # Set my-param to the `my-param` output of `another-stack`
+    my-param:
+      stack: another-stack
+
+    # Set my-param to the `my-output` output of `another-stack`
+    my-param:
+      stack: another-stack
+      output: my-output
 ```
 
 ## Usage

--- a/lib/cfn_flow.rb
+++ b/lib/cfn_flow.rb
@@ -113,6 +113,7 @@ module CfnFlow
     # Clear aws sdk clients & config (for tests)
     def clear!
       @config = @cfn_client = @cfn_resource = nil
+      CachedStack.stack_cache.clear
     end
 
     # Exit with status code = 1 when raising a Thor::Error
@@ -131,6 +132,7 @@ module CfnFlow
   end
 end
 
+require 'cfn_flow/cached_stack'
 require 'cfn_flow/template'
 require 'cfn_flow/git'
 require 'cfn_flow/event_presenter'

--- a/lib/cfn_flow.rb
+++ b/lib/cfn_flow.rb
@@ -39,7 +39,7 @@ module CfnFlow
       unless config['stack'].is_a? Hash
         raise Thor::Error.new("No stack defined in #{config_path}. Add 'stack: ...'.")
       end
-      params = StackParams.expand(config['stack'])
+      params = StackParams.expanded(config['stack'])
 
       params.
         add_tag('CfnFlowService' => service).

--- a/lib/cfn_flow.rb
+++ b/lib/cfn_flow.rb
@@ -133,6 +133,7 @@ module CfnFlow
 end
 
 require 'cfn_flow/cached_stack'
+require 'cfn_flow/stack_params'
 require 'cfn_flow/template'
 require 'cfn_flow/git'
 require 'cfn_flow/event_presenter'

--- a/lib/cfn_flow.rb
+++ b/lib/cfn_flow.rb
@@ -39,43 +39,11 @@ module CfnFlow
       unless config['stack'].is_a? Hash
         raise Thor::Error.new("No stack defined in #{config_path}. Add 'stack: ...'.")
       end
+      params = StackParams.expand(config['stack'])
 
-      # Dup & symbolize keys
-      params = config['stack'].map{|k,v| [k.to_sym, v]}.to_h
-
-      # Expand params
-      if params[:parameters].is_a? Hash
-        expanded_params = params[:parameters].map do |key,value|
-          { parameter_key: key, parameter_value: value }
-        end
-        params[:parameters] = expanded_params
-      end
-
-      # Expand tags
-      if params[:tags].is_a? Hash
-        tags = params[:tags].map do |key, value|
-          {key: key, value: value}
-        end
-
-        params[:tags] = tags
-      end
-
-      # Append CfnFlow tags
-      params[:tags] ||= []
-      params[:tags] << { key: 'CfnFlowService', value: service }
-      params[:tags] << { key: 'CfnFlowEnvironment', value: environment }
-
-      # Expand template body
-      if params[:template_body].is_a? String
-        begin
-          body = CfnFlow::Template.new(params[:template_body]).to_json
-          params[:template_body] = body
-        rescue CfnFlow::Template::Error
-          # Do nothing
-        end
-      end
-
-      params
+      params.
+        add_tag('CfnFlowService' => service).
+        add_tag('CfnFlowEnvironment' => environment)
     end
 
     def template_s3_bucket

--- a/lib/cfn_flow/cached_stack.rb
+++ b/lib/cfn_flow/cached_stack.rb
@@ -1,0 +1,32 @@
+module CfnFlow
+  class CachedStack
+
+    class MissingOutput < StandardError; end
+
+    def self.stack_cache
+      @stack_cache ||= {}
+    end
+
+    def self.get_output(stack:, output:)
+      new(stack).output(output)
+    end
+
+    attr_reader :stack_name
+
+    def initialize(stack_name)
+      @stack_name = stack_name
+    end
+
+    def output(name)
+      output = stack_cache.outputs.detect{|out| out.output_key == name }
+      unless output
+        raise MissingOutput.new("Can't find outpout #{name} for stack #{stack_name}")
+      end
+      output.output_value
+    end
+
+    def stack_cache
+      self.class.stack_cache[stack_name] ||= CfnFlow.cfn_resource.stack(stack_name).load
+    end
+  end
+end

--- a/lib/cfn_flow/stack_params.rb
+++ b/lib/cfn_flow/stack_params.rb
@@ -3,22 +3,22 @@ module CfnFlow
   # style of hash aws-sdk expects
   class StackParams < Hash
 
-    def self.expand(hash)
+    def self.expanded(hash)
       self[hash].
-        symbolized_keys.
-        expand_parameters.
-        expand_tags.
-        expand_template_body
+        with_symbolized_keys.
+        with_expanded_parameters.
+        with_expanded_tags.
+        with_expanded_template_body
     end
 
-    def symbolized_keys
+    def with_symbolized_keys
       self.inject(StackParams.new) do |accum, pair|
         key, value = pair
         accum.merge(key.to_sym => value)
       end
     end
 
-    def expand_parameters
+    def with_expanded_parameters
       return self unless self[:parameters].is_a? Hash
 
       expanded_params = self[:parameters].map do |key,value|
@@ -28,7 +28,7 @@ module CfnFlow
       self.merge(parameters: expanded_params)
     end
 
-    def expand_tags
+    def with_expanded_tags
       return self unless self[:tags].is_a? Hash
 
       tags = self[:tags].map do |key, value|
@@ -46,7 +46,7 @@ module CfnFlow
       self.merge(tags: tags)
     end
 
-    def expand_template_body
+    def with_expanded_template_body
       return self unless self[:template_body].is_a? String
       body = CfnFlow::Template.new(self[:template_body]).to_json
       self.merge(template_body: body)

--- a/lib/cfn_flow/stack_params.rb
+++ b/lib/cfn_flow/stack_params.rb
@@ -1,0 +1,66 @@
+module CfnFlow
+  # Extend hash with some special behavior to generate the
+  # style of hash aws-sdk expects
+  class StackParams < Hash
+
+    def self.expand(hash)
+      self[hash].
+        symbolized_keys.
+        expand_parameters.
+        expand_tags.
+        expand_template_body
+    end
+
+    def symbolized_keys
+      self.inject(StackParams.new) do |accum, pair|
+        key, value = pair
+        accum.merge(key.to_sym => value)
+      end
+    end
+
+    def expand_parameters
+      return self unless self[:parameters].is_a? Hash
+
+      expanded_params = self[:parameters].map do |key,value|
+        # Dereference stack output params
+        if value.is_a?(Hash) && value.key?('stack')
+          stack_name = value['stack']
+          stack_output_name = value['output'] || key
+
+          value = CachedStack.get_output(stack: stack_name, output: stack_output_name)
+        end
+
+        { parameter_key: key, parameter_value: value }
+      end
+
+      self.merge(parameters: expanded_params)
+    end
+
+    def expand_tags
+      return self unless self[:tags].is_a? Hash
+
+      tags = self[:tags].map do |key, value|
+        {key: key, value: value}
+      end
+
+      self.merge(tags: tags)
+    end
+
+    def add_tag(hash)
+      tags = self[:tags] || []
+      hash.each do |k,v|
+        tags << {key: k, value: v }
+      end
+      self.merge(tags: tags)
+    end
+
+    def expand_template_body
+      return self unless self[:template_body].is_a? String
+      body = CfnFlow::Template.new(self[:template_body]).to_json
+      self.merge(template_body: body)
+    rescue CfnFlow::Template::Error
+      # Do nothing
+      self
+    end
+  end
+end

--- a/lib/cfn_flow/version.rb
+++ b/lib/cfn_flow/version.rb
@@ -1,3 +1,3 @@
 module CfnFlow
-  VERSION = '0.8.0'
+  VERSION = '0.9.0'
 end

--- a/spec/cfn_flow/cached_stack_spec.rb
+++ b/spec/cfn_flow/cached_stack_spec.rb
@@ -1,0 +1,71 @@
+require_relative '../helper'
+
+describe 'CfnFlow::CachedStack' do
+  subject { CfnFlow::CachedStack }
+
+  describe '.stack_cache' do
+    it 'defaults to a hash' do
+      subject.stack_cache.must_equal({})
+    end
+  end
+
+  describe '.get_output' do
+    let(:output_value) { 'myvalue' }
+
+    before do
+      Aws.config[:cloudformation]= {
+        stub_responses: {
+          describe_stacks: { stacks: [ stub_stack_data.merge(outputs: [{ output_key: "myoutput", output_value: output_value } ]) ] }
+        }
+      }
+    end
+
+    it 'returns the output' do
+      subject.get_output(stack: 'mystack', output: 'myoutput').must_equal output_value
+    end
+
+    it 'has required kwargs' do
+      -> { subject.get_output }.must_raise(ArgumentError)
+    end
+  end
+
+  describe 'an instance' do
+    subject { CfnFlow::CachedStack.new('mystack') }
+    let(:output_value) { 'myvalue' }
+
+    before do
+      Aws.config[:cloudformation]= {
+        stub_responses: {
+          describe_stacks: { stacks: [ stub_stack_data.merge(outputs: [{ output_key: "myoutput", output_value: output_value } ]) ] }
+        }
+      }
+    end
+
+    it "should return the output value" do
+      subject.output('myoutput').must_equal output_value
+    end
+
+    describe "with a missing output" do
+      it "should raise an error" do
+        -> { subject.output("no-such-output") }.must_raise(CfnFlow::CachedStack::MissingOutput)
+      end
+    end
+
+    describe "with a missing stack" do
+
+      subject { CfnFlow::CachedStack.new('no-such-stack') }
+      before do
+        Aws.config[:cloudformation]= {
+          stub_responses: {
+            describe_stacks: 'ValidationError'
+          }
+        }
+      end
+
+      it "should raise an error" do
+        -> { subject.output('blah') }.must_raise(Aws::CloudFormation::Errors::ValidationError)
+      end
+    end
+  end
+
+end

--- a/spec/cfn_flow/stack_params_spec.rb
+++ b/spec/cfn_flow/stack_params_spec.rb
@@ -7,19 +7,19 @@ describe 'CfnFlow::StackParams' do
     subject.new.must_be_kind_of Hash
   end
 
-  describe '.expand' do
+  describe '.expanded' do
     it "returns a StackParams hash" do
-      subject.expand({}).must_be_kind_of subject
+      subject.expanded({}).must_be_kind_of subject
     end
   end
 
-  describe '#symbolized_keys' do
+  describe '#with_symbolized_keys' do
     it 'works' do
-      subject[{'foo' => 1, :bar => true}].symbolized_keys.must_equal({foo: 1, bar: true})
+      subject[{'foo' => 1, :bar => true}].with_symbolized_keys.must_equal({foo: 1, bar: true})
     end
   end
 
-  describe '#expand_parameters' do
+  describe '#with_expanded_parameters' do
     it 'reformats parameters hash to array of hashes' do
       hash = {
         parameters: { 'k1' => 'v1', 'k2' => 'v2' }
@@ -32,7 +32,7 @@ describe 'CfnFlow::StackParams' do
         ]
       }
 
-      subject[hash].expand_parameters.must_equal expected
+      subject[hash].with_expanded_parameters.must_equal expected
     end
 
     describe 'with stack outputs' do
@@ -57,7 +57,7 @@ describe 'CfnFlow::StackParams' do
           parameters: [ {parameter_key: 'my-key', parameter_value: output_value} ]
         }
 
-        subject[hash].expand_parameters.must_equal expected
+        subject[hash].with_expanded_parameters.must_equal expected
       end
 
       it 'fetches stack outputs with implicit output key' do
@@ -70,16 +70,16 @@ describe 'CfnFlow::StackParams' do
           parameters: [ {parameter_key: output_key, parameter_value: output_value} ]
         }
 
-        subject[hash].expand_parameters.must_equal expected
+        subject[hash].with_expanded_parameters.must_equal expected
       end
     end
   end
 
-  describe '#expand_tags' do
+  describe '#with_expanded_tags' do
     it 'expands tags hash to array of hashes' do
       hash = {tags: {'k' => 'v'} }
       expected = {tags: [{key: 'k', value: 'v'}]}
-      subject[hash].expand_tags.must_equal expected
+      subject[hash].with_expanded_tags.must_equal expected
     end
   end
 
@@ -97,15 +97,15 @@ describe 'CfnFlow::StackParams' do
     end
   end
 
-  describe '#expand_template_body' do
+  describe '#with_expanded_template_body' do
     it 'does not expand invalid templates' do
       hash = { template_body: 'spec/data/invalid.yml' }
-      subject[hash].expand_template_body.must_equal hash
+      subject[hash].with_expanded_template_body.must_equal hash
     end
 
     it 'expands valid template paths' do
       template_path = 'spec/data/sqs.template'
-      result = subject[template_body: template_path].expand_template_body
+      result = subject[template_body: template_path].with_expanded_template_body
 
       result.must_equal({template_body: CfnFlow::Template.new(template_path).to_json})
     end

--- a/spec/cfn_flow/stack_params_spec.rb
+++ b/spec/cfn_flow/stack_params_spec.rb
@@ -1,0 +1,114 @@
+require_relative '../helper'
+
+describe 'CfnFlow::StackParams' do
+  subject { CfnFlow::StackParams }
+
+  it 'should be a hash' do
+    subject.new.must_be_kind_of Hash
+  end
+
+  describe '.expand' do
+    it "returns a StackParams hash" do
+      subject.expand({}).must_be_kind_of subject
+    end
+  end
+
+  describe '#symbolized_keys' do
+    it 'works' do
+      subject[{'foo' => 1, :bar => true}].symbolized_keys.must_equal({foo: 1, bar: true})
+    end
+  end
+
+  describe '#expand_parameters' do
+    it 'reformats parameters hash to array of hashes' do
+      hash = {
+        parameters: { 'k1' => 'v1', 'k2' => 'v2' }
+      }
+
+      expected = {
+        parameters: [
+          {parameter_key: 'k1', parameter_value: 'v1'},
+          {parameter_key: 'k2', parameter_value: 'v2'}
+        ]
+      }
+
+      subject[hash].expand_parameters.must_equal expected
+    end
+
+    describe 'with stack outputs' do
+      let(:output_key)   { 'my-output-key' }
+      let(:output_value) { 'my-output-value' }
+
+      before do
+        Aws.config[:cloudformation]= {
+          stub_responses: {
+            describe_stacks: { stacks: [ stub_stack_data.merge(outputs: [{ output_key: output_key, output_value: output_value } ]) ] }
+          }
+        }
+      end
+
+      it 'fetches stack outputs with explicit output key' do
+        hash = {
+          parameters: {
+            'my-key' => { 'stack' => 'my-stack', 'output' => output_key}
+          }
+        }
+        expected = {
+          parameters: [ {parameter_key: 'my-key', parameter_value: output_value} ]
+        }
+
+        subject[hash].expand_parameters.must_equal expected
+      end
+
+      it 'fetches stack outputs with implicit output key' do
+        hash = {
+          parameters: {
+            output_key => { 'stack' => 'my-stack'}
+          }
+        }
+        expected = {
+          parameters: [ {parameter_key: output_key, parameter_value: output_value} ]
+        }
+
+        subject[hash].expand_parameters.must_equal expected
+      end
+    end
+  end
+
+  describe '#expand_tags' do
+    it 'expands tags hash to array of hashes' do
+      hash = {tags: {'k' => 'v'} }
+      expected = {tags: [{key: 'k', value: 'v'}]}
+      subject[hash].expand_tags.must_equal expected
+    end
+  end
+
+  describe '#add_tag' do
+    it 'sets an empty tag hash' do
+      subject.new.add_tag('k' => 'v').must_equal({tags: [{key: 'k', value: 'v'}]})
+
+    end
+    it 'appends to existing tag hash' do
+      orig = subject[{tags: [{key: 'k1', value: 'v1'}] }]
+      expected = {tags: [{key: 'k1', value: 'v1'}, {key: 'k2', value: 'v2'}] }
+
+      orig.add_tag('k2' => 'v2').must_equal expected
+
+    end
+  end
+
+  describe '#expand_template_body' do
+    it 'does not expand invalid templates' do
+      hash = { template_body: 'spec/data/invalid.yml' }
+      subject[hash].expand_template_body.must_equal hash
+    end
+
+    it 'expands valid template paths' do
+      template_path = 'spec/data/sqs.template'
+      result = subject[template_body: template_path].expand_template_body
+
+      result.must_equal({template_body: CfnFlow::Template.new(template_path).to_json})
+    end
+  end
+
+end

--- a/spec/cfn_flow_spec.rb
+++ b/spec/cfn_flow_spec.rb
@@ -50,22 +50,9 @@ describe 'CfnFlow' do
       error.message.must_match 'No stack defined'
     end
 
-    it('expands parameters') do
-      stack = {'parameters' => {'ami' => 'ami-12345' } }
-      subject.instance_variable_set(:@config, {'service' => 'myservice', 'stack' => stack})
-      subject.stack_params('env')[:parameters].must_equal [ { parameter_key: 'ami', parameter_value: 'ami-12345' } ]
-    end
-
-    it('expands tags') do
-      stack = {'tags' => {'Deployer' => 'Aaron' } }
-      subject.instance_variable_set(:@config, {'service' => 'myservice', 'stack' => stack})
-      expected = [
-        { key: 'Deployer', value: 'Aaron' },
-        { key: 'CfnFlowService', value: 'myservice' },
-        { key: 'CfnFlowEnvironment', value: 'env' }
-      ]
-
-      subject.stack_params('env')[:tags].must_equal expected
+    it('returns a StackParams hash') do
+      subject.instance_variable_set(:@config, {'service' => 'myservice', 'stack' => {}})
+      subject.stack_params('env').must_be_kind_of CfnFlow::StackParams
     end
 
     it 'appends CfnFlow tags' do
@@ -77,14 +64,6 @@ describe 'CfnFlow' do
 
       subject.stack_params('env')[:tags].must_equal expected
     end
-
-    it 'expands template body' do
-      template_path = 'spec/data/sqs.template'
-      stack = {'template_body' => template_path}
-      subject.instance_variable_set(:@config, {'service' => 'myservice', 'stack' => stack})
-      subject.stack_params('env')[:template_body].must_equal CfnFlow::Template.new(template_path).to_json
-    end
-
   end
 
   describe '.template_s3_bucket' do


### PR DESCRIPTION
This adds the ability to reference another stack's output as input parameters in `cfn-flow.yml`. This is useful to easily include values from backing templates in your deployments.

For example:

```yaml
stack:
  parameters:
      ##
      # Use outputs from other stacks

      # This set the `load_balancer` parameter to the value of the
      # `elbname` output of `my-elb-stack`
      load_balancer:
        stack: my-elb-stack
        output: elbname

      # If you don't specify the output name, it's assumed to be same
      # as the parameter key:
      ssh_security_group:
        stack: my-bastion-stack
```

This also extracts a lot of unwieldy code from `CfnFlow.stack_params` to a more easily tested `StackParams` class.

(Wrote this pairing with @talaris :wave:)