### PR TITLE
StackParams#with_symbolized_keys: Use terse reduce syntax

### DIFF
--- a/lib/cfn_flow/stack_params.rb
+++ b/lib/cfn_flow/stack_params.rb
@@ -12,8 +12,7 @@ module CfnFlow
     end
 
     def with_symbolized_keys
-      self.inject(StackParams.new) do |accum, pair|
-        key, value = pair
+      self.reduce(StackParams.new) do |accum, (key, value)|
         accum.merge(key.to_sym => value)
       end
     end


### PR DESCRIPTION
cc @talaris, we were trying to remember how to access hash key/value in `reduce` goalposts. :smile: 

```ruby
hash.reduce(...) { |accum, (key, value)| ... }