### PR TITLE
Support new aws-sdk versions

### DIFF
--- a/cfn-flow.gemspec
+++ b/cfn-flow.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.2.0'
 
-  s.add_dependency 'aws-sdk', '~> 2.1.8'
+  s.add_dependency 'aws-sdk', '>= 2.1.8', '~> 2.1'
   s.add_dependency 'thor', '~> 0.18'
   s.add_dependency 'multi_json'
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,12 +1,12 @@
 dependencies:
   pre:
-    - rvm install 2.2.3
-    - rvm install 2.3.0
+    - rvm install 2.2.5
+    - rvm install 2.3.1
   override:
-    - rvm-exec 2.2.3 bash -c "bundle check --path=vendor/bundle || bundle install --path=vendor/bundle"
-    - rvm-exec 2.3.0 bash -c "bundle check --path=vendor/bundle || bundle install --path=vendor/bundle"
+    - rvm-exec 2.2.5 bash -c "bundle check --path=vendor/bundle || bundle install --path=vendor/bundle"
+    - rvm-exec 2.3.1 bash -c "bundle check --path=vendor/bundle || bundle install --path=vendor/bundle"
 
 test:
   override:
-    - rvm-exec 2.2.3 bash -c "bin/rake test"
-    - rvm-exec 2.3.0 bash -c "bin/rake test"
+    - rvm-exec 2.2.5 bash -c "bin/rake test"
+    - rvm-exec 2.3.1 bash -c "bin/rake test"

--- a/lib/cfn_flow/version.rb
+++ b/lib/cfn_flow/version.rb
@@ -1,3 +1,3 @@
 module CfnFlow
-  VERSION = '0.11.0'
+  VERSION = '0.11.1'
 end


### PR DESCRIPTION
We want at least v2.1.8, and can support v2.x.y (e.g. the current 2.5.6)